### PR TITLE
Start implementing standard API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,49 @@ pkg> add Mimi
 ## Running the model
 
 The model uses the Mimi framework and it is highly recommended to read the Mimi documentation first to understand the code structure. For starter code on running the model just once, see the code in the file `examples/main.jl`.
+
+The basic way to access a copy of the default MimiDICE2013 model is the following:
+```
+using MimiDICE2013
+
+m = MimiDICE2013.get_model()
+run(m)
+```
+
+## Calculating the Social Cost of Carbon
+
+Here is an example of computing the social cost of carbon with MimiDICE2013. Note that the units of the returned value are dollars $/ton CO2.
+```
+using Mimi
+using MimiDICE2013
+
+# Get the social cost of carbon in year 2020 from the default MimiDICE2013 model:
+scc = MimiDICE2013.compute_scc(year = 2020)
+
+# You can also compute the SCC from a modified version of a MimiDICE2013 model:
+m = MimiDICE2013.get_model()    # Get the default version of the MimiDICE2013 model
+update_param!(m, :t2xco2, 5)    # Try a higher climate sensitivity value
+scc = MimiDICE2013.compute_scc(m, year=2020)    # compute the scc from the modified model by passing it as the first argument to compute_scc
+```
+The first argument to the `compute_scc` function is a MimiDICE2013 model, and it is an optional argument. If no model is provided, the default MimiDICE2013 model will be used. 
+There are also other keyword arguments available to `compute_scc`. Note that the user must specify a `year` for the SCC calculation, but the rest of the keyword arguments have default values.
+```
+compute_scc(m = get_model(),  # if no model provided, will use the default MimiDICE2013 model
+    year = nothing,  # user must specify an emission year for the SCC calculation
+    last_year = 2305,  # the last year to run and use for the SCC calculation. Default is the last year of the time dimension, 2305.
+    prtp = 0.03,  # pure rate of time preference parameter used for constant discounting
+)
+```
+There is an additional function for computing the SCC that also returns the MarginalModel that was used to compute it. It returns these two values as a NamedTuple of the form (scc=scc, mm=mm). The same keyword arguments from the `compute_scc` function are available for the `compute_scc_mm` function. Example:
+```
+using Mimi
+using MimiDICE2013
+
+result = MimiDICE2013.compute_scc_mm(year=2030, last_year=2300, prtp=0.025)
+
+result.scc  # returns the computed SCC value
+
+result.mm   # returns the Mimi MarginalModel
+
+marginal_temp = result.mm[:climatedynamics, :TATM]  # marginal results from the marginal model can be accessed like this
+```

--- a/examples/main.jl
+++ b/examples/main.jl
@@ -1,7 +1,7 @@
 using Mimi
 using MimiDICE2013
 
-DICE = getdiceexcel()
+DICE = MimiDICE2013.get_model()
 run(DICE)
 
 explore(DICE)

--- a/src/MimiDICE2013.jl
+++ b/src/MimiDICE2013.jl
@@ -19,10 +19,12 @@ include("components/welfare_component.jl")
 
 export constructdice, getdiceexcel, getdicegams
 
+const model_years = 2010:5:2305
+
 function constructdice(p)
 
     m = Model()
-    set_dimension!(m, :time, 2010:5:2305)
+    set_dimension!(m, :time, model_years)
 
     add_comp!(m, grosseconomy, :grosseconomy)
     add_comp!(m, emissions, :emissions)
@@ -126,5 +128,8 @@ function getdicegams(;datafile = joinpath(dirname(@__FILE__), "..", "Data", "DIC
 
     return m
 end
+
+# get_model function for standard Mimi API: use the Excel version
+get_model = getdiceexcel
 
 end # module

--- a/src/marginaldamage.jl
+++ b/src/marginaldamage.jl
@@ -1,3 +1,85 @@
+"""
+compute_scc(m::Model=get_model(); year::Int = nothing, last_year::Int = 2305), prtp::Float64 = 0.03)
+
+Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiDICE2013 model. 
+If no model is provided, the default model from MimiDICE2013.get_model() is used.
+Constant discounting is used from the specified pure rate of time preference `prtp`.
+"""
+function compute_scc(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = model_years[end], prtp::Float64 = 0.03)
+    year === nothing ? error("Must specify an emission year. Try `compute_scc(m, year=2020)`.") : nothing
+    !(last_year in model_years) ? error("Invlaid value of $last_year for last_year. last_year must be within the model's time index $model_years.") : nothing
+    !(year in model_years[1]:5:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index $(model_years[1]):5:$last_year.") : nothing
+
+    mm = get_marginal_model(m; year = year)
+
+    return _compute_scc(mm, year=year, last_year=last_year, prtp=prtp)
+end
+
+"""
+compute_scc_mm(m::Model=get_model(); year::Int = nothing, last_year::Int = 2305, prtp::Float64 = 0.03)
+
+Returns a NamedTuple (scc=scc, mm=mm) of the social cost of carbon and the MarginalModel used to compute it.
+Computes the social cost of CO2 for an emissions pulse in `year` for the provided MimiDICE2013 model. 
+If no model is provided, the default model from MimiDICE2013.get_model() is used.
+Constant discounting is used from the specified pure rate of time preference `prtp`.
+"""
+function compute_scc_mm(m::Model=get_model(); year::Union{Int, Nothing} = nothing, last_year::Int = model_years[end], prtp::Float64 = 0.03)
+    year === nothing ? error("Must specify an emission year. Try `compute_scc_mm(m, year=2020)`.") : nothing
+    !(last_year in model_years) ? error("Invlaid value of $last_year for last_year. last_year must be within the model's time index $model_years.") : nothing
+    !(year in model_years[1]:5:last_year) ? error("Cannot compute the scc for year $year, year must be within the model's time index $(model_years[1]):5:$last_year.") : nothing
+
+    mm = get_marginal_model(m; year = year)
+    scc = _compute_scc(mm; year=year, last_year=last_year, prtp=prtp)
+    
+    return (scc = scc, mm = mm)
+end
+
+# helper function for computing SCC from a MarginalModel, not to be exported or advertised to users
+function _compute_scc(mm::MarginalModel; year::Int, last_year::Int, prtp::Float64)
+    ntimesteps = findfirst(isequal(last_year), model_years)     # Will run through the timestep of the specified last_year 
+    run(mm, ntimesteps=ntimesteps)
+
+    marginal_damages = -1 * mm[:neteconomy, :C][1:ntimesteps] * 10^12     # Go from trillion$ to $; multiply by -1 so that damages are positive; pulse was in CO2 so we don't need to multiply by 12/44
+
+    df = [zeros(length(model_years[1]:5:year)-1)..., [1/(1+prtp)^(t-year) for t in year:5:last_year]...]
+    scc = sum(df .* marginal_damages * 5)  # currently implemented as a 5year step function; so each timestep of discounted marginal damages is multiplied by 5
+    return scc
+end
+
+"""
+get_marginal_model(m::Model = get_model(); year::Int = nothing)
+
+Creates a Mimi MarginalModel where the provided m is the base model, and the marginal model has additional emissions of CO2 in year `year`.
+If no Model m is provided, the default model from MimiDICE2013.get_model() is used as the base model.
+"""
+function get_marginal_model(m::Model=get_model(); year::Union{Int, Nothing} = nothing)
+    year === nothing ? error("Must specify an emission year. Try `get_marginal_model(m, year=2015)`.") : nothing
+    !(year in model_years) ? error("Cannot add marginal emissions in $year, year must be within the model's time index $(model_years[1]):10:$last_year.") : nothing
+
+    mm = create_marginal_model(m, 5 * 1e9)    # 1 GtCO2 per year for 5 years, so 5 * 10^9
+    add_marginal_emissions!(mm.marginal, year)
+
+    return mm
+end
+
+"""
+Adds a marginal emission component to year m which adds 1Gt of additional CO2 emissions per year for ten years starting in the specified `year`.
+"""
+function add_marginal_emissions!(m::Model, year::Int) 
+    add_comp!(m, Mimi.adder, :marginalemission, before=:co2cycle)
+
+    time = Mimi.dimension(m, :time)
+    addem = zeros(length(time))
+    addem[time[year]] = 1.0     # 1 GtCO2 per year for ten years
+
+    set_param!(m, :marginalemission, :add, addem)
+    connect_param!(m, :marginalemission, :input, :emissions, :E)
+    connect_param!(m, :co2cycle, :E, :marginalemission, :output)
+end
+
+
+
+# Old available marginal model function 
 function getmarginal_dice_models(;emissionyear=2010)
 
     DICE = constructdice()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ using MimiDICE2013: getparams
 
 @testset "MimiDICE2013-model" begin
 
-m = getdiceexcel();
+m = MimiDICE2013.get_model();
 run(m)
 
 f = openxl(joinpath(dirname(@__FILE__), "..", "Data", "DICE_2013_Excel.xlsm"))
@@ -74,7 +74,7 @@ end #MimiDICE2013-model testset
 Precision = 1.0e-11
 nullvalue = -999.999
 
-m = getdiceexcel();
+m = MimiDICE2013.get_model();
 run(m)
 
 for c in map(name, Mimi.compdefs(m)), v in Mimi.variable_names(m, c)
@@ -107,6 +107,45 @@ for c in map(name, Mimi.compdefs(m)), v in Mimi.variable_names(m, c)
 end #for loop
 
 end #MimiDICE2013-integration testset
+
+@testset "Standard API" begin
+
+m = MimiDICE2013.get_model()
+run(m)
+
+# Test the errors
+@test_throws ErrorException MimiDICE2013.compute_scc()  # test that it errors if you don't specify a year
+@test_throws ErrorException MimiDICE2013.compute_scc(year=2021)  # test that it errors if the year isn't in the time index
+@test_throws ErrorException MimiDICE2013.compute_scc(last_year=2299)  # test that it errors if the last_year isn't in the time index
+@test_throws ErrorException MimiDICE2013.compute_scc(year=2105, last_year=2100)  # test that it errors if the year is after last_year
+
+# Test the SCC 
+scc1 = MimiDICE2013.compute_scc(year=2020)
+@test scc1 isa Float64
+
+# Test that it's smaller with a shorter horizon
+scc2 = MimiDICE2013.compute_scc(year=2020, last_year=2200)
+@test scc2 < scc1
+
+# Test that it's larger with a smaller prtp
+scc3 = MimiDICE2013.compute_scc(year=2020, last_year=2200, prtp=0.02)
+@test scc3 > scc2
+
+# Test with a modified model 
+m = MimiDICE2013.get_model()
+update_param!(m, :t2xco2, 5)    
+scc4 = MimiDICE2013.compute_scc(m, year=2020)
+@test scc4 > scc1   # Test that a higher value of climate sensitivty makes the SCC bigger
+
+# Test compute_scc_mm
+result = MimiDICE2013.compute_scc_mm(year=2030)
+@test result.scc isa Float64
+@test result.mm isa Mimi.MarginalModel
+marginal_temp = result.mm[:climatedynamics, :TATM]
+@test all(marginal_temp[1:findfirst(isequal(2030), MimiDICE2013.model_years)] .== 0.)
+@test all(marginal_temp[findfirst(isequal(2035), MimiDICE2013.model_years):end] .!= 0.)
+
+end
 
 end #MimiDICE2013 testset
 


### PR DESCRIPTION
Questions:
- I think emissions are already in Gt CO2, so I'm pretty sure we don't have to multiply by 12/44.
- Timestep length is 5 years, so currently I implemented the pulse to just be an additional 1 GtCO2 for 5 years. should I make the pulse last for two timesteps so that it is for 10 years?