### PR TITLE
Update simulation to match new API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,6 @@ ExcelReaders = "c04bee98-12a5-510c-87df-2a230cb6e075"
 [compat]
 Mimi = "0.9"
 ExcelReaders = "0.11"
-CSVFiles = "0.16.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ ExcelReaders = "c04bee98-12a5-510c-87df-2a230cb6e075"
 [compat]
 Mimi = "0.9"
 ExcelReaders = "0.11"
+CSVFiles = "0.16.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/mcs.jl
+++ b/src/mcs.jl
@@ -11,8 +11,4 @@ mcs = @defsim begin
     save(damages.DAMAGES)
 end
 
-generate_trials!(mcs, 10000, filename="/tmp/dice-2013/trialdata.csv")
-
-# Run trials 1:4, and save results to the indicated directory
-set_models!(mcs, m)
-run_sim(mcs, output_dir="/tmp/dice-2013")
+run(mcs, m, 1000; trials_output_filename = "/tmp/dice-2013/trialdata.csv", results_output_dir="/tmp/dice-2013")

--- a/src/mcs.jl
+++ b/src/mcs.jl
@@ -11,4 +11,4 @@ mcs = @defsim begin
     save(damages.DAMAGES)
 end
 
-run(mcs, m, 1000; trials_output_filename = "/tmp/dice-2013/trialdata.csv", results_output_dir="/tmp/dice-2013")
+res = run(mcs, m, 1000; trials_output_filename = "/tmp/dice-2013/trialdata.csv", results_output_dir="/tmp/dice-2013")


### PR DESCRIPTION
This PR updates all the `mcs` code to use the new Simulation API in Mimi v0.9.3. @davidanthoff this is ready to be merged (Travis is passing, ApVeyor is failing for an unrelated reason I can look into)